### PR TITLE
Measurement deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.3] - 14-03-2021
+### Added
+- Measurement deletion by bucket timestamp
+
+### Updated
+- Measurement deletion HTTP route
+
+### Removed
+- Measurement deletion between timestamps
+- Invalid documentation
+
 ## [1.3.2] - 13-03-2021
 ### Updated
 - Measurement query's

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ensured through clever use of caches and document stores.
 
 [header1]: https://github.com/sensate-iot/SensateService/workflows/Docker/badge.svg "Docker Build"
 [header2]: https://github.com/sensate-iot/SensateService/workflows/Format%20check/badge.svg ".NET format"
-[header3]: https://img.shields.io/badge/version-v1.3.2-informational "Sensate IoT version"
+[header3]: https://img.shields.io/badge/version-v1.3.3-informational "Sensate IoT version"
 
 ## Sensor communication
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ensured through clever use of caches and document stores.
 
 [header1]: https://github.com/sensate-iot/SensateService/workflows/Docker/badge.svg "Docker Build"
 [header2]: https://github.com/sensate-iot/SensateService/workflows/Format%20check/badge.svg ".NET format"
-[header3]: https://img.shields.io/badge/version-v1.1.0-informational "Sensate IoT version"
+[header3]: https://img.shields.io/badge/version-v1.3.2-informational "Sensate IoT version"
 
 ## Sensor communication
 

--- a/SensateIoT.API/SensateIoT.API.Common.Core/Infrastructure/Document/CachedMeasurementRepository.cs
+++ b/SensateIoT.API/SensateIoT.API.Common.Core/Infrastructure/Document/CachedMeasurementRepository.cs
@@ -61,19 +61,6 @@ namespace SensateIoT.API.Common.Core.Infrastructure.Document
 			return data == null ? null : JsonConvert.DeserializeObject<IEnumerable<MeasurementsQueryResult>>(data);
 		}
 
-		public override async Task DeleteBetweenAsync(Sensor sensor, DateTime start, DateTime end, CancellationToken ct = default)
-		{
-			string key;
-
-			key = $"{sensor.InternalId}::{start.ToString(CultureInfo.InvariantCulture)}::{end.ToString(CultureInfo.InvariantCulture)}";
-			var tasks = new[] {
-				this._cache.RemoveAsync(key, ct),
-				base.DeleteBetweenAsync(sensor, start, end, ct)
-			};
-
-			await Task.WhenAll(tasks).AwaitBackground();
-		}
-
 		public override async Task<IEnumerable<MeasurementsQueryResult>> GetBetweenAsync(Sensor sensor,
 																						 DateTime start,
 																						 DateTime end,

--- a/SensateIoT.API/SensateIoT.API.Common.Core/Infrastructure/Document/MeasurementRepository.cs
+++ b/SensateIoT.API/SensateIoT.API.Common.Core/Infrastructure/Document/MeasurementRepository.cs
@@ -15,7 +15,7 @@ using Microsoft.Extensions.Logging;
 
 using MongoDB.Bson;
 using MongoDB.Driver;
-
+using SensateIoT.API.Common.Core.Exceptions;
 using SensateIoT.API.Common.Core.Helpers;
 using SensateIoT.API.Common.Core.Infrastructure.Repositories;
 using SensateIoT.API.Common.Core.Services.DataProcessing;
@@ -39,20 +39,17 @@ namespace SensateIoT.API.Common.Core.Infrastructure.Document
 			this.m_geoService = geo;
 		}
 
-		public virtual async Task DeleteBetweenAsync(Sensor sensor, DateTime start, DateTime end, CancellationToken ct = default)
+		public virtual async Task DeleteBucketAsync(Sensor sensor, DateTime bucket, CancellationToken ct)
 		{
 			try {
 				var builder = Builders<MeasurementBucket>.Filter;
-				var filter = builder.ElemMatch(x => x.Measurements,
-											   x => x.Timestamp >= start) &
-							 builder.ElemMatch(x => x.Measurements,
-											   x => x.Timestamp < end) &
-							 builder.Eq(x => x.SensorId, sensor.InternalId);
+				var filter = builder.Eq(x => x.SensorId, sensor.InternalId) &
+				             builder.Eq(x => x.Timestamp, bucket.ThisHour());
 
-				await this._collection.DeleteManyAsync(filter, ct).AwaitBackground();
-			} catch(Exception ex) {
-				this._logger.LogInformation($"Unable to delete measurements: {ex.Message}");
-				this._logger.LogDebug(ex.StackTrace);
+				await this._collection.DeleteManyAsync(filter, ct).ConfigureAwait(false);
+			} catch(MongoException ex) {
+				this._logger.LogError(ex, "Unable to remove buckets (bucket: {bucket:O}, sensor: {sensor}).", bucket, sensor.InternalId);
+				throw new DatabaseException($"Unable to remove {bucket:O} from database (Sensor: {sensor.InternalId}", "Measurements", ex);
 			}
 		}
 

--- a/SensateIoT.API/SensateIoT.API.Common.Core/Infrastructure/Repositories/IMeasurementRepository.cs
+++ b/SensateIoT.API/SensateIoT.API.Common.Core/Infrastructure/Repositories/IMeasurementRepository.cs
@@ -10,13 +10,10 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
-using MongoDB.Bson;
-
 using SensateIoT.API.Common.Data.Dto.Generic;
 using SensateIoT.API.Common.Data.Enums;
 using SensateIoT.API.Common.Data.Models;
 
-using MeasurementModel = SensateIoT.API.Common.Data.Models.Measurement;
 using MeasurementsQueryResult = SensateIoT.API.Common.Data.Models.MeasurementsQueryResult;
 
 namespace SensateIoT.API.Common.Core.Infrastructure.Repositories
@@ -38,6 +35,6 @@ namespace SensateIoT.API.Common.Core.Infrastructure.Repositories
 		Task<IEnumerable<MeasurementsQueryResult>> GetMeasurementsNearAsync(IEnumerable<Sensor> sensors, DateTime start, DateTime end, GeoJsonPoint coords,
 			int max = 100, int skip = -1, int limit = -1, OrderDirection order = OrderDirection.None, CancellationToken ct = default);
 
-		Task DeleteBetweenAsync(Sensor sensor, DateTime start, DateTime end, CancellationToken ct = default);
+		Task DeleteBucketAsync(Sensor sensor, DateTime bucket, CancellationToken ct);
 	}
 }


### PR DESCRIPTION
Fix various measurement deletion issues by simplifying the deletion process.

## Description
The old deletion process allows deletion of individual measurements, which is very hard to get right as measurements are bucketed together.

## Motivation and Context
This patch fixes problems with measurement deletion.

## How Has This Been Tested?
This patch has been verified using manual testing only.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

