### PR TITLE
Measurement deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.4] - 14-03-2021
+### Added
+- Bucket range deletion
+- Bucket end parameter to the measurement deletion route
+
+### Updated
+- Measurement deletion route
+
 ## [1.3.3] - 14-03-2021
 ### Added
 - Measurement deletion by bucket timestamp

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ ensured through clever use of caches and document stores.
 
 [header1]: https://github.com/sensate-iot/SensateService/workflows/Docker/badge.svg "Docker Build"
 [header2]: https://github.com/sensate-iot/SensateService/workflows/Format%20check/badge.svg ".NET format"
-[header3]: https://img.shields.io/badge/version-v1.3.3-informational "Sensate IoT version"
+[header3]: https://img.shields.io/badge/version-v1.3.4-informational "Sensate IoT version"
 
 ## Sensor communication
 

--- a/SensateIoT.API/SensateIoT.API.Common.Core/Infrastructure/Document/MeasurementRepository.cs
+++ b/SensateIoT.API/SensateIoT.API.Common.Core/Infrastructure/Document/MeasurementRepository.cs
@@ -49,10 +49,10 @@ namespace SensateIoT.API.Common.Core.Infrastructure.Document
 
 				await this._collection.DeleteManyAsync(filter, ct).ConfigureAwait(false);
 			} catch(MongoException ex) {
-				this._logger.LogError(ex, "Unable to remove buckets (bucket: {bucketStart:O} - {bucketEnd:O}, sensor: {sensor}).", 
-				                      bucketStart, bucketEnd, sensor.InternalId);
+				this._logger.LogError(ex, "Unable to remove buckets (bucket: {bucketStart:O} - {bucketEnd:O}, sensor: {sensor}).",
+									  bucketStart, bucketEnd, sensor.InternalId);
 				throw new DatabaseException($"Unable to remove {bucketStart:O} - {bucketEnd:O} from database (Sensor: {sensor.InternalId}",
-				                            "Measurements", ex);
+											"Measurements", ex);
 			}
 		}
 

--- a/SensateIoT.API/SensateIoT.API.Common.Core/Infrastructure/Repositories/IMeasurementRepository.cs
+++ b/SensateIoT.API/SensateIoT.API.Common.Core/Infrastructure/Repositories/IMeasurementRepository.cs
@@ -35,6 +35,6 @@ namespace SensateIoT.API.Common.Core.Infrastructure.Repositories
 		Task<IEnumerable<MeasurementsQueryResult>> GetMeasurementsNearAsync(IEnumerable<Sensor> sensors, DateTime start, DateTime end, GeoJsonPoint coords,
 			int max = 100, int skip = -1, int limit = -1, OrderDirection order = OrderDirection.None, CancellationToken ct = default);
 
-		Task DeleteBucketAsync(Sensor sensor, DateTime bucket, CancellationToken ct);
+		Task DeleteBucketAsync(Sensor sensor, DateTime bucketStart, DateTime bucketEnd, CancellationToken ct);
 	}
 }

--- a/SensateIoT.API/SensateIoT.API.DataApi/Controllers/MeasurementsController.cs
+++ b/SensateIoT.API/SensateIoT.API.DataApi/Controllers/MeasurementsController.cs
@@ -169,7 +169,7 @@ namespace SensateIoT.API.DataApi.Controllers
 		[ProducesResponseType(204)]
 		[ProducesResponseType(401)]
 		[ProducesResponseType(404)]
-		public async Task<IActionResult> Delete([FromQuery] string sensorId, [FromQuery] DateTime bucket)
+		public async Task<IActionResult> Delete([FromQuery] string sensorId, [FromQuery] DateTime bucketStart, DateTime bucketEnd)
 		{
 			Sensor sensor;
 
@@ -184,9 +184,9 @@ namespace SensateIoT.API.DataApi.Controllers
 					return this.Unauthorized();
 				}
 
-				await this.m_measurements.DeleteBucketAsync(sensor, bucket, CancellationToken.None).ConfigureAwait(false);
+				await this.m_measurements.DeleteBucketAsync(sensor, bucketStart, bucketEnd, CancellationToken.None).ConfigureAwait(false);
 			} catch(DatabaseException ex) {
-				this.m_logger.LogWarning(ex, $"Unable to delete measurements for sensor {sensorId} in bucket {bucket}.");
+				this.m_logger.LogWarning(ex, $"Unable to delete measurements for sensor {sensorId} in bucket {bucketStart} - {bucketEnd}.");
 				return this.StatusCode(500);
 			}
 


### PR DESCRIPTION
Improve measurement deletion by adding a range parameter.

## Description
The previous measurement deletion improvement (accidentally) removed the ability to perform range deletes. This patch adds the ability to delete a range of measurements based on timestamps.

## Motivation and Context
Adding the ability to delete entire ranges of data.

## How Has This Been Tested?
Manual tests have been performed on development machines.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.

